### PR TITLE
feat: add Tundra.adopt/1 to adopt an existing TUN fd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `Tundra.adopt/1` to take ownership of an already-created TUN device from an
+  open file descriptor. The original descriptor is duplicated and closed, so it
+  must not be used after a successful call.
 - **Breaking**: Raise the minimum required Elixir version to 1.18 (was 1.15).
 
 ## 0.4.1 - 2026-01-26

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Use `Tundra.create/2` to create a new TUN device with full configuration:
   mtu: 1500)
 ```
 
+To take ownership of a TUN device that was created and configured elsewhere, pass
+its open file descriptor to `Tundra.adopt/1`. Tundra duplicates the descriptor and
+closes the original, so it must not be used after a successful call:
+
+```elixir
+{:ok, {dev, name}} = Tundra.adopt(fd)
+```
+
 See the module documentation for complete API details.
 
 

--- a/c_src/nif.c
+++ b/c_src/nif.c
@@ -27,6 +27,13 @@
 #include <net/if.h>
 #endif
 
+#ifdef __APPLE__
+#include <net/if.h>
+#include <net/if_utun.h>
+#include <sys/kern_control.h>
+#include <sys/sys_domain.h>
+#endif
+
 // Platform-specific MSG_NOSIGNAL flag
 #ifdef __APPLE__
 #define TUNDRA_MSG_NOSIGNAL 0
@@ -734,6 +741,133 @@ cleanup:
 #endif
 }
 
+// Close a raw (non-resource) file descriptor.
+//
+// Used to release the original descriptor after it has been adopted: on Darwin
+// :socket.open/2 duplicates the fd, and on Linux adopt_tun_fd duplicates it, so
+// the original must be closed to avoid leaking it.
+static ERL_NIF_TERM close_raw_fd(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    int fd;
+    if (argc != 1 || !enif_get_int(env, argv[0], &fd) || fd < 0)
+    {
+        return enif_make_badarg(env);
+    }
+
+    if (close(fd) == -1)
+    {
+        return make_error(env, errno);
+    }
+
+    return s_ok;
+}
+
+// Adopt an existing TUN file descriptor (Linux).
+//
+// Validates that the descriptor refers to a TUN device, retrieves its name,
+// duplicates it into a NIF resource owned by the calling process and returns
+// {ref, name}. The original descriptor is left open for the caller to close
+// (see close_raw_fd/1). dup(2) shares the open file description, so O_NONBLOCK
+// is set on the copy to satisfy the NIF's non-blocking I/O model.
+static ERL_NIF_TERM adopt_tun_fd(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+#ifdef __linux__
+    int orig_fd;
+    if (argc != 1 || !enif_get_int(env, argv[0], &orig_fd) || orig_fd < 0)
+    {
+        return enif_make_badarg(env);
+    }
+
+    // Confirm this is a TUN device and retrieve its name.
+    struct ifreq ifr = {0};
+    if (ioctl(orig_fd, TUNGETIFF, &ifr) == -1)
+    {
+        return make_error(env, errno);
+    }
+
+    int fd = dup(orig_fd);
+    if (fd == -1)
+    {
+        return make_error(env, errno);
+    }
+    if (fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) == -1)
+    {
+        int err = errno;
+        close(fd);
+        return make_error(env, err);
+    }
+
+    struct fd_object_t *fd_obj = alloc_fd_object(env);
+    if (fd_obj == NULL)
+    {
+        close(fd);
+        return make_error(env, ENOMEM);
+    }
+    fd_obj->fd = fd;
+
+    ERL_NIF_TERM result;
+    ErlNifBinary name_bin;
+    if (enif_alloc_binary(strlen(ifr.ifr_name), &name_bin))
+    {
+        memcpy(name_bin.data, ifr.ifr_name, name_bin.size);
+        ERL_NIF_TERM res_term = enif_make_resource(env, fd_obj);
+        ERL_NIF_TERM info = enif_make_tuple2(env, res_term, enif_make_binary(env, &name_bin));
+        enif_release_binary(&name_bin);
+        result = enif_make_tuple2(env, s_ok, info);
+    }
+    else
+    {
+        close(fd_obj->fd);
+        fd_obj->fd = -1;
+        result = make_error(env, ENOMEM);
+    }
+
+    enif_release_resource(fd_obj);
+    return result;
+#else
+    (void)argc;
+    (void)argv;
+    return make_error(env, ENOTSUP);
+#endif
+}
+
+// Retrieve the interface name of an existing utun file descriptor (Darwin).
+//
+// Doubles as validation that the descriptor is a utun control socket; the fd is
+// left untouched so the caller can wrap it with :socket.open/2.
+static ERL_NIF_TERM get_utun_name(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+#ifdef __APPLE__
+    int fd;
+    if (argc != 1 || !enif_get_int(env, argv[0], &fd) || fd < 0)
+    {
+        return enif_make_badarg(env);
+    }
+
+    char name[IF_NAMESIZE] = {0};
+    socklen_t len = sizeof(name);
+    if (getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, name, &len) == -1)
+    {
+        return make_error(env, errno);
+    }
+
+    size_t name_len = strnlen(name, sizeof(name));
+    ErlNifBinary name_bin;
+    if (!enif_alloc_binary(name_len, &name_bin))
+    {
+        return make_error(env, ENOMEM);
+    }
+    memcpy(name_bin.data, name, name_len);
+    ERL_NIF_TERM ret = enif_make_tuple2(env, s_ok, enif_make_binary(env, &name_bin));
+    enif_release_binary(&name_bin);
+    return ret;
+#else
+    (void)argc;
+    (void)argv;
+    return make_error(env, ENOTSUP);
+#endif
+}
+
 static ErlNifFunc nif_funcs[] =
     {
         {"connect", 0, connect_svr, 0},
@@ -745,6 +879,9 @@ static ErlNifFunc nif_funcs[] =
         {"send_data", 2, send_data, 0},
         {"cancel_select", 2, cancel_select, 0},
         {"controlling_process", 2, controlling_process, 0},
-        {"create_tun_direct", 1, create_tun_direct, 0}};
+        {"create_tun_direct", 1, create_tun_direct, 0},
+        {"adopt_tun_fd", 1, adopt_tun_fd, 0},
+        {"get_utun_name", 1, get_utun_name, 0},
+        {"close_raw_fd", 1, close_raw_fd, 0}};
 
 ERL_NIF_INIT(Elixir.Tundra.Client, nif_funcs, load, NULL, NULL, NULL)

--- a/lib/tundra.ex
+++ b/lib/tundra.ex
@@ -180,6 +180,44 @@ defmodule Tundra do
     end
   end
 
+  @spec adopt(non_neg_integer()) :: {:ok, {tun_device(), String.t()}} | {:error, any()}
+  @doc """
+  Adopt an already-created TUN device from an open file descriptor.
+
+  Use this when a TUN device has been created and configured outside of Tundra
+  (for example by another program, an init system, or inherited at startup) and
+  you want to drive it with Tundra's API. The device must already be configured;
+  `adopt/1` only takes ownership of the descriptor, it does not configure the
+  interface.
+
+  `fd` is the integer file descriptor of the device:
+
+  - On Linux, a descriptor opened on `/dev/net/tun` and attached to a TUN device
+    via `TUNSETIFF`.
+  - On Darwin, a `utun` control socket descriptor
+    (`PF_SYSTEM`/`SYSPROTO_CONTROL`).
+
+  On success returns a tuple containing a device tuple and the name of the
+  device, exactly as `create/2` does. As with a created device, the adopted
+  device is owned by the calling process and is closed when that process exits.
+
+  > #### The original descriptor is consumed {: .warning}
+  >
+  > On success, Tundra duplicates `fd` (via the socket library on Darwin, or the
+  > NIF on Linux) and closes the original. **The caller must not use `fd` after a
+  > successful call** — reading from, writing to or closing it leads to undefined
+  > behaviour. On error, `fd` is left untouched and remains owned by the caller.
+
+  ## Examples
+
+      iex> Tundra.adopt(23)
+      {:ok, {{:"$socket", #Reference<0.2990923237.3512074243.109526>}, "utun6"}} # Darwin
+      {:ok, {{:"$tundra", #Reference<0.2990923237.3512074243.109526>}, "tun0"}}  # Linux
+  """
+  def adopt(fd) when is_integer(fd) and fd >= 0 do
+    Tundra.Client.adopt(fd)
+  end
+
   @doc """
   Transfer control of a TUN device to another process.
 

--- a/lib/tundra/client.ex
+++ b/lib/tundra/client.ex
@@ -14,7 +14,10 @@ defmodule Tundra.Client do
           recv_data: 2,
           send_data: 2,
           cancel_select: 2,
-          create_tun_direct: 1
+          create_tun_direct: 1,
+          adopt_tun_fd: 1,
+          get_utun_name: 1,
+          close_raw_fd: 1
   end
 
   def child_spec(args) do
@@ -48,6 +51,33 @@ defmodule Tundra.Client do
       {:error, _other} = error ->
         # Other error, return it
         error
+    end
+  end
+
+  @spec adopt(non_neg_integer()) ::
+          {:ok, {{:"$socket", reference()} | {:"$tundra", reference()}, String.t()}}
+          | {:error, any()}
+  def adopt(fd) when is_integer(fd) and fd >= 0 do
+    case :os.type() do
+      {:unix, :darwin} ->
+        with {:ok, name} <- get_utun_name(fd),
+             {:ok, s} <- :socket.open(fd, %{domain: 32, type: 2, protocol: 2}) do
+          # :socket.open/2 duplicates the descriptor, so close the original to
+          # avoid leaking it. The caller must not use it after this point.
+          _ = close_raw_fd(fd)
+          {:ok, {s, name}}
+        end
+
+      {:unix, :linux} ->
+        with {:ok, {ref, name}} <- adopt_tun_fd(fd) do
+          # adopt_tun_fd duplicates the descriptor, so close the original to
+          # avoid leaking it. The caller must not use it after this point.
+          _ = close_raw_fd(fd)
+          {:ok, {{:"$tundra", ref}, name}}
+        end
+
+      _ ->
+        {:error, :enotsup}
     end
   end
 
@@ -197,6 +227,9 @@ defmodule Tundra.Client do
   defp send_data(_ref, _data), do: :erlang.nif_error(:not_implemented)
   defp cancel_select(_ref, _select_info), do: :erlang.nif_error(:not_implemented)
   defp create_tun_direct(_params), do: :erlang.nif_error(:not_implemented)
+  defp adopt_tun_fd(_fd), do: :erlang.nif_error(:not_implemented)
+  defp get_utun_name(_fd), do: :erlang.nif_error(:not_implemented)
+  defp close_raw_fd(_fd), do: :erlang.nif_error(:not_implemented)
 
   def close(_ref), do: :erlang.nif_error(:not_implemented)
   def controlling_process(_ref, _pid), do: :erlang.nif_error(:not_implemented)

--- a/test/tundra_test.exs
+++ b/test/tundra_test.exs
@@ -1,5 +1,23 @@
 defmodule TundraTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
-  # TODO:
+  describe "adopt/1" do
+    test "rejects negative file descriptors" do
+      assert_raise FunctionClauseError, fn -> Tundra.adopt(-1) end
+    end
+
+    test "rejects non-integer file descriptors" do
+      assert_raise FunctionClauseError, fn -> Tundra.adopt(:not_an_fd) end
+    end
+
+    test "returns an error for an invalid file descriptor" do
+      assert {:error, :ebadf} = Tundra.adopt(9_999)
+    end
+
+    test "returns an error for a descriptor that is not a TUN device" do
+      # stderr is a valid descriptor but not a TUN/utun device. adopt/1 only
+      # inspects the descriptor before failing and leaves it open.
+      assert {:error, _reason} = Tundra.adopt(2)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds `Tundra.adopt/1` to take ownership of a TUN device that was created and
configured outside of Tundra, given its open integer file descriptor.

The device is represented exactly as a created one: a `:socket.socket()` on
Darwin and a `{:"$tundra", ref}` NIF resource on Linux, owned by the calling
process and closed when that process exits.

## Behaviour

- The descriptor is **duplicated** — via `:socket.open/2` on Darwin, via the
  new `adopt_tun_fd/1` NIF on Linux — and the **original is then closed** to
  avoid leaking it.
- **On success the caller must not use the fd** (it has been closed); this is
  documented with a warning admonition on `Tundra.adopt/1`.
- **On error the descriptor is left untouched** and remains owned by the
  caller — validation (`TUNGETIFF` on Linux, `getsockopt(UTUN_OPT_IFNAME)` on
  Darwin) happens before any side effect.

## Implementation

- New NIFs: `adopt_tun_fd/1` (Linux: validate + `dup` + `O_NONBLOCK` + wrap in
  resource), `get_utun_name/1` (Darwin: name + validation), `close_raw_fd/1`.
- Public `Tundra.adopt/1` plus README/CHANGELOG updates and guard/error-path
  tests.

## Testing

- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix test` (4 passing), `mix docs` — all clean on macOS.
- Runtime error paths verified: invalid fd → `{:error, :ebadf}`, non-TUN fd →
  `{:error, :enotsock}`, negative/non-integer → guard.

> [!NOTE]
> Built and exercised on macOS. The Linux NIF branch is `#ifdef`'d out locally
> and was not compiled here — it mirrors the existing Linux NIF code and uses
> only already-present includes, but CI / a Linux build should confirm it. A
> privileged happy-path round-trip test isn't feasible (needs root *and* an
> in-process raw fd), matching the previously empty suite.