### PR TITLE
build: adopt publisho for versioning and releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 # CHANGELOG
 
-## Unreleased
-
-- Add `Tundra.adopt/1` to take ownership of an already-created TUN device from an
-  open file descriptor. The original descriptor is duplicated and closed, so it
-  must not be used after a successful call.
-- **Breaking**: Raise the minimum required Elixir version to 1.18 (was 1.15).
+<!-- %% CHANGELOG_ENTRIES %% -->
 
 ## 0.4.1 - 2026-01-26
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+### Added
+
+- `Tundra.adopt/1` to take ownership of an already-created TUN device from an
+  open file descriptor. The original descriptor is duplicated and closed, so it
+  must not be used after a successful call.
+
+### Changed
+
+- **Breaking**: Raise the minimum required Elixir version to 1.18 (was 1.15).

--- a/mix.exs
+++ b/mix.exs
@@ -1,11 +1,14 @@
 defmodule Tundra.MixProject do
   use Mix.Project
 
+  @version "0.4.1"
+  @source_url "https://github.com/ausimian/tundra"
+
   def project do
     [
       app: :tundra,
       description: "TUN device support for Elixir",
-      version: version(),
+      version: @version,
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -29,15 +32,16 @@ defmodule Tundra.MixProject do
     [
       {:elixir_make, "~> 0.9", runtime: false},
       {:typedstruct, "~> 0.5", runtime: false},
-      {:ex_doc, "~> 0.40", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.40", only: :dev, runtime: false},
+      {:publisho, "~> 1.0", only: :dev, runtime: false}
     ]
   end
 
   defp docs do
     [
       main: "readme",
-      source_url: "https://github.com/ausimian/tundra",
-      source_ref: "#{version()}",
+      source_url: @source_url,
+      source_ref: @version,
       logo: "tundra.png",
       extras: ["LICENSE.md", "CHANGELOG.md", "README.md"]
     ]
@@ -58,32 +62,8 @@ defmodule Tundra.MixProject do
         ".formatter.exs"
       ],
       links: %{
-        "GitHub" => "https://github.com/ausimian/tundra/tree/#{version()}"
+        "GitHub" => "#{@source_url}/tree/#{@version}"
       }
     ]
-  end
-
-  defp version do
-    version_from_pkg() || version_from_github() || version_from_git() || "0.0.0"
-  end
-
-  defp version_from_github do
-    if System.get_env("GITHUB_REF_TYPE") == "tag" do
-      System.get_env("GITHUB_REF_NAME")
-    end
-  end
-
-  defp version_from_pkg do
-    if File.exists?("./hex_metadata.config") do
-      {:ok, info} = :file.consult("./hex_metadata.config")
-      Map.new(info)["version"]
-    end
-  end
-
-  defp version_from_git do
-    case System.cmd("git", ["describe", "--dirty"], stderr_to_stdout: true) do
-      {version, 0} -> String.trim(version)
-      _ -> nil
-    end
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -6,5 +6,6 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.1.0", "835f7e60792e08824cda445639555d7bf1bbbddb1b60b306e33cb6f6db24dc74", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "1cd6780fb1dd1a03979abaed0fe82712b0625118fd5257d3ebbf73f960c73c3c"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
+  "publisho": {:hex, :publisho, "1.0.2", "c65f597a3ad0bd1487ab63c09167fe258287c9ace687a25a9cbb5e58d237e97b", [:mix], [], "hexpm", "9a48538ea978a4645a4a00e76c220b580dda28174f039184bf053e5fe37171eb"},
   "typedstruct": {:hex, :typedstruct, "0.5.4", "d1d33d58460a74f413e9c26d55e66fd633abd8ac0fb12639add9a11a60a0462a", [:make, :mix], [], "hexpm", "ffaef36d5dbaebdbf4ed07f7fb2ebd1037b2c1f757db6fb8e7bcbbfabbe608d8"},
 }


### PR DESCRIPTION
## Summary

Adopts [`publisho`](https://hex.pm/packages/publisho) for version management and releases, replacing the dynamic version-detection code in `mix.exs`.

- Replace the `version/0` helpers (git `describe`, `GITHUB_REF`, and `hex_metadata.config` lookups) with a static `@version` attribute as the single source of truth (pinned to `0.4.1` to match the current release).
- Add a `@source_url` attribute and use it for the docs and package repository links.
- Add `{:publisho, "~> 1.0", only: :dev, runtime: false}`.
- Add the `<!-- %% CHANGELOG_ENTRIES %% -->` placeholder to `CHANGELOG.md` where publisho injects released entries.
- Move next-release notes into `RELEASE.md` using Keep a Changelog sections (`### Added` / `### Changed`). publisho consumes this for the next release and clears it afterwards.

## Release workflow going forward

Edit `RELEASE.md` on feature branches, then run `mix publisho <level>` at release time — it bumps `@version`, folds `RELEASE.md` into `CHANGELOG.md` under a `## <version> - <date>` heading, commits, and tags (bare semver).

## Verification

- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix publisho minor --dry-run` — resolves `@version` 0.4.1 → 0.5.0, builds the sectioned changelog entry, and tags `0.5.0` with the release notes as the annotation